### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,7 +622,7 @@ Review the [Contributing Guidelines](https://github.com/donnemartin/gitsome/blob
 
 ## Credits
 
-* [click](https://github.com/mitsuhiko/click) by [mitsuhiko](https://github.com/mitsuhiko)
+* [click](https://github.com/pallets/click) by [mitsuhiko](https://github.com/mitsuhiko)
 * [github_trends_rss](https://github.com/ryotarai/github_trends_rss) by [ryotarai](https://github.com/ryotarai)
 * [github3.py](https://github.com/sigmavirus24/github3.py) by [sigmavirus24](https://github.com/sigmavirus24)
 * [html2text](https://github.com/aaronsw/html2text) by [aaronsw](https://github.com/aaronsw)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ gitsome
 
 >A Supercharged Git/Shell Autocompleter with GitHub Integration.
 
-[![Build Status](https://travis-ci.org/donnemartin/gitsome.svg?branch=master)](https://travis-ci.org/donnemartin/gitsome) [![PyPI version](https://badge.fury.io/py/gitsome.svg)](http://badge.fury.io/py/gitsome) [![PyPI](https://img.shields.io/pypi/pyversions/gitsome.svg)](https://pypi.python.org/pypi/gitsome/) [![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
+[![Build Status](https://travis-ci.org/donnemartin/gitsome.svg?branch=master)](https://travis-ci.org/donnemartin/gitsome) [![PyPI version](https://badge.fury.io/py/gitsome.svg)](http://badge.fury.io/py/gitsome) [![PyPI](https://img.shields.io/pypi/pyversions/gitsome.svg)](https://pypi.python.org/pypi/gitsome/) [![License](https://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 
 ## Motivation
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/mitsuhiko/click | https://github.com/pallets/click 


### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://img.shields.io/:license-apache-blue.svg | https://img.shields.io/:license-apache-blue.svg
