### PR TITLE
Changed prompt-toolkit version & updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,12 @@ Depending on your system, you might need to run `pip3`, possibly with the `-H` f
 
     $ sudo -H pip3 install gitsome
 
+For most linux users, `pip3` can be installed on your system using the `python3-pip` package. 
+
+For example, Ubuntu users can use:
+
+    $ sudo apt-get install python-pip3
+
 See this [ticket](https://github.com/donnemartin/gitsome/issues/4) for more details.
 
 #### Starting the `gitsome` Shell
@@ -625,6 +631,17 @@ If you're interested in contributing to `gitsome`, run the following commands:
     $ pip install -r requirements-dev.txt
     $ gitsome
     $ gh <command> [param] [options]
+
+If you get an error while installing saying that you need Python 3.4, it could be because your pip command is configured for an older version of Python. To fix this issue, it is recommended to install pip3:
+
+    $ sudo apt-get install python3-pip
+
+Then the above pip commands can be replaced with:
+
+    $ pip3 install -e .
+    $ pip3 install -r requirements-dev.txt
+
+See this [ticket](https://github.com/donnemartin/gitsome/issues/4) for more details.
 
 ### Continuous Integration
 

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ def main():
         skw['install_requires'] = [
             'numpydoc==0.5',
             'ply==3.4',
-            'prompt-toolkit==0.51',
+            'prompt-toolkit==0.52',
             'requests==2.8.1',
             'colorama>=0.3.3',
             'click>=5.1',


### PR DESCRIPTION
Fix for issue #21.

This allows gitsome to be compatible with haxor-news. Incompatibility was caused because of conflict in the requirement of prompt-toolkit versions. 

Was unable to update egg-info since it was in .gitignore

Also updated README.md to include relevant details for pip and Python version related issue (refer #4). 