### PR TITLE
Fix typo for --private flag in 'gh feed' command

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -174,11 +174,11 @@ Example(s):
 
 List all activity for the given user or repo.
 
-If `user_or_repo` is not provided, uses the logged in user's news feed seen while visiting https://github.com.  If `user_or_repo` is provided, shows either the public or `[-p/--private]` feed activity of the user or repo.
+If `user_or_repo` is not provided, uses the logged in user's news feed seen while visiting https://github.com.  If `user_or_repo` is provided, shows either the public or `[-pr/--private]` feed activity of the user or repo.
 
 Usage:
 
-    $ gh feed [user_or_repo] [-p/--private] [-p/--pager]
+    $ gh feed [user_or_repo] [-pr/--private] [-p/--pager]
 
 Param(s):
 

--- a/gitsome/githubcli.py
+++ b/gitsome/githubcli.py
@@ -196,11 +196,11 @@ class GitHubCli(object):
 
         If `user_or_repo` is not provided, uses the logged in user's news feed
         seen while visiting https://github.com.  If `user_or_repo` is provided,
-        shows either the public or `[-p/--private]` feed activity of the user
+        shows either the public or `[-pr/--private]` feed activity of the user
         or repo.
 
         Usage:
-            gh feed [user_or_repo] [-p/--private] [-p/--pager]
+            gh feed [user_or_repo] [-pr/--private] [-p/--pager]
 
         Examples:
             gh feed


### PR DESCRIPTION
As we have discussed in the issue #38.