### PR TITLE
Fix #49: create-repo error if no description specified

### DIFF
--- a/gitsome/github.py
+++ b/gitsome/github.py
@@ -247,8 +247,10 @@ class GitHub(object):
             repo = self.config.api.create_repository(repo_name,
                                                      repo_desc,
                                                      private=private)
+
+            description = repo.description if repo.description is not None else ''
             click.secho(('Created repo: ' + repo.full_name + '\n' +
-                         repo.description),
+                         description),
                         fg=self.config.clr_message)
         except UnprocessableEntity as e:
             click.secho('Error creating repo: ' + str(e.msg),


### PR DESCRIPTION
This fixes #49 with the same solution that fixed #40 as you suggested. 

I've also checked another functions of `GitHub` class searching for bugs like this, but didn't found something else left. Since seems that python API uses `None` as placeholder for optional arguments, I would write a wrapper around `click.secho()` to handle `None`s as empty strings so this bug would never arise again.