### PR TITLE
Update tests based on fixes for #40 and #48

### DIFF
--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -75,6 +75,13 @@ class GitHubTest(unittest.TestCase):
             fg=self.github.config.clr_message)
 
     @mock.patch('gitsome.github.click.secho')
+    def test_create_issue_no_desc(self, mock_click_secho):
+        self.github.create_issue('user1/repo1', 'title', issue_desc=None)
+        mock_click_secho.assert_called_with(
+            'Created issue: title\n',
+            fg=self.github.config.clr_message)
+
+    @mock.patch('gitsome.github.click.secho')
     def test_create_issue_invalid_args(self, mock_click_secho):
         self.github.create_issue('invalid/repo1', 'title', 'desc')
         mock_click_secho.assert_called_with(
@@ -90,6 +97,13 @@ class GitHubTest(unittest.TestCase):
         self.github.create_repo('name', 'desc', True)
         mock_click_secho.assert_called_with(
             'Created repo: name\ndesc',
+            fg=self.github.config.clr_message)
+
+    @mock.patch('gitsome.github.click.secho')
+    def test_create_repo_no_desc(self, mock_click_secho):
+        self.github.create_repo('name', repo_desc=None)
+        mock_click_secho.assert_called_with(
+            'Created repo: name\n',
             fg=self.github.config.clr_message)
 
     @mock.patch('gitsome.github.click.secho')


### PR DESCRIPTION
Unit test updates for:

### Bug Fixes

* [#40](https://github.com/donnemartin/gitsome/issues/40) - Fix `create-issue` `NoneType` error if no `-b/--body` is specified.
* [#48](https://github.com/donnemartin/gitsome/issues/48) - Fix `create-repo` `NoneType` error if no `-d/--description` is specified.