### PR TITLE
Only store password in config for GitHub Enterprise (due to Enterprise limitations)

### DIFF
--- a/gitsome/config.py
+++ b/gitsome/config.py
@@ -51,9 +51,6 @@ class Config(object):
     :type CONFIG_USER_LOGIN: str
     :param CONFIG_USER_LOGIN: The user login.
 
-    :type CONFIG_USER_PASS: str
-    :param CONFIG_USER_PASS: The user password.
-
     :type CONFIG_USER_TOKEN: str
     :param CONFIG_USER_TOKEN: The user token.
 
@@ -89,9 +86,6 @@ class Config(object):
     :type user_login: str
     :param user_login: The user's login in ~/.gitsomeconfig.
 
-    :type user_pass: str
-    :param user_pass: The user's pass in ~/.gitsomeconfig.
-
     :type user_token: str
     :param user_token: The user's token in ~/.gitsomeconfig.
 
@@ -122,7 +116,6 @@ class Config(object):
     CONFIG_CLR_VIEW_INDEX = 'clr_view_index'
     CONFIG_SECTION = 'github'
     CONFIG_USER_LOGIN = 'user_login'
-    CONFIG_USER_PASS = 'user_pass'
     CONFIG_USER_TOKEN = 'user_token'
     CONFIG_USER_FEED = 'user_feed'
     CONFIG_ENTERPRISE_URL = 'enterprise_url'
@@ -135,7 +128,6 @@ class Config(object):
     def __init__(self):
         self.api = None
         self.user_login = None
-        self.user_pass = None
         self.user_token = None
         self.user_feed = None
         self.enterprise_url = None
@@ -190,9 +182,6 @@ class Config(object):
             self.user_login = self.load_config(
                 parser=parser,
                 cfg_label=self.CONFIG_USER_LOGIN)
-            self.user_pass = self.load_config(
-                parser=parser,
-                cfg_label=self.CONFIG_USER_PASS)
             self.user_token = self.load_config(
                 parser=parser,
                 cfg_label=self.CONFIG_USER_TOKEN)
@@ -221,9 +210,7 @@ class Config(object):
                     'url': self.enterprise_url,
                     'verify': self.verify_ssl,
                 })
-                if self.user_pass is not None:
-                    login_kwargs.update({'password': self.user_pass})
-                elif self.user_token is not None:
+                if self.user_token is not None:
                     login_kwargs.update({'token': self.user_token})
                 else:
                     self.print_auth_error()
@@ -285,16 +272,17 @@ class Config(object):
             if click.confirm(('Do you want to log in with a password [Y] or '
                               'a personal access token [n]?'),
                              default=True):
-                while not self.user_pass:
-                    self.user_pass = self.getpass('Password: ')
-                login_kwargs.update({'password': self.user_pass})
+                user_pass = None
+                while not user_pass:
+                    user_pass = self.getpass('Password: ')
+                login_kwargs.update({'password': user_pass})
                 try:
                     if not enterprise:
                         # Trade the user password for a personal access token.
                         # This does not seem to be available for Enterprise.
                         auth = self.authorize(
                             self.user_login,
-                            self.user_pass,
+                            user_pass,
                             scopes=['user', 'repo'],
                             note='gitsome',
                             note_url='https://github.com/donnemartin/gitsome',
@@ -616,10 +604,8 @@ class Config(object):
             parser.set(self.CONFIG_SECTION,
                        self.CONFIG_USER_LOGIN,
                        self.user_login)
-            if self.user_pass is not None:
-                parser.set(self.CONFIG_SECTION,
-                           self.CONFIG_USER_PASS,
-                           self.user_pass)
+            parser.remove_option(self.CONFIG_SECTION,
+                                 'user_pass')
             if self.user_token is not None:
                 parser.set(self.CONFIG_SECTION,
                            self.CONFIG_USER_TOKEN,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -126,11 +126,9 @@ class ConfigTest(unittest.TestCase):
 
     def test_authenticate_cached_credentials_pass_enterprise(self):
         self.github.config.user_login = 'foo'
-        self.github.config.user_pass = 'bar'
         self.github.config.enterprise_url = 'baz'
         self.github.config.save_config()
         self.github.config.user_login = ''
-        self.github.config.user_pass = ''
         self.github.config.enterprise_url = ''
         self.github.config.api = None
         config = self.github.config.get_github_config_path(
@@ -141,7 +139,6 @@ class ConfigTest(unittest.TestCase):
             parser,
             enterprise_auth=self.verify_login_pass_url_enterprise)
         assert self.github.config.user_login == 'foo'
-        assert self.github.config.user_pass == 'bar'
         assert self.github.config.enterprise_url == 'baz'
 
     @mock.patch('gitsome.github.click.secho')
@@ -163,7 +160,6 @@ class ConfigTest(unittest.TestCase):
             with mock.patch('builtins.input', return_value='foo'):
                 self.github.config.login = self.verify_login_pass
                 self.github.config.user_login = 'foo'
-                self.github.config.user_pass = 'bar'
                 self.github.config.authenticate(
                     enterprise=False,
                     overwrite=True)
@@ -188,7 +184,6 @@ class ConfigTest(unittest.TestCase):
         with mock.patch('click.confirm', return_value=True):
             with mock.patch('builtins.input', return_value='foo'):
                 self.github.config.user_login = 'foo'
-                self.github.config.user_pass = 'bar'
                 self.github.config.authenticate(
                     enterprise=True,
                     enterprise_auth=self.verify_login_pass_url_enterprise,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -49,6 +49,7 @@ class ConfigTest(unittest.TestCase):
                           verify=True):
         assert username is not None
         assert password is not None
+        assert password
         assert two_factor_callback is not None
         assert verify
 
@@ -104,6 +105,20 @@ class ConfigTest(unittest.TestCase):
         assert self.github.config.user_login == 'foo'
         assert self.github.config.user_token == 'bar'
 
+    def test_authenticate_cached_credentials_pass(self):
+        self.github.config.user_login = 'foo'
+        self.github.config.user_pass = 'bar'
+        self.github.config.save_config()
+        self.github.config.user_login = ''
+        self.github.config.user_pass = ''
+        self.github.config.api = None
+        config = self.github.config.get_github_config_path(
+            self.github.config.CONFIG)
+        parser = configparser.RawConfigParser()
+        self.github.config.authenticate_cached_credentials(config, parser)
+        assert self.github.config.user_login == 'foo'
+        assert self.github.config.user_pass is None
+
     def test_authenticate_cached_credentials_token_enterprise(self):
         self.github.config.user_login = 'foo'
         self.github.config.user_token = 'bar'
@@ -126,9 +141,11 @@ class ConfigTest(unittest.TestCase):
 
     def test_authenticate_cached_credentials_pass_enterprise(self):
         self.github.config.user_login = 'foo'
+        self.github.config.user_pass = 'bar'
         self.github.config.enterprise_url = 'baz'
         self.github.config.save_config()
         self.github.config.user_login = ''
+        self.github.config.user_pass = ''
         self.github.config.enterprise_url = ''
         self.github.config.api = None
         config = self.github.config.get_github_config_path(
@@ -139,6 +156,7 @@ class ConfigTest(unittest.TestCase):
             parser,
             enterprise_auth=self.verify_login_pass_url_enterprise)
         assert self.github.config.user_login == 'foo'
+        assert self.github.config.user_pass == 'bar'
         assert self.github.config.enterprise_url == 'baz'
 
     @mock.patch('gitsome.github.click.secho')
@@ -156,6 +174,7 @@ class ConfigTest(unittest.TestCase):
     @mock.patch('gitsome.github.click.secho')
     @mock.patch('gitsome.config.Config.authenticate_cached_credentials')
     def test_authenticate_pass(self, mock_auth, mock_click_secho):
+        self.github.config.getpass.return_value = 'bar'
         with mock.patch('click.confirm', return_value=True):
             with mock.patch('builtins.input', return_value='foo'):
                 self.github.config.login = self.verify_login_pass
@@ -163,6 +182,7 @@ class ConfigTest(unittest.TestCase):
                 self.github.config.authenticate(
                     enterprise=False,
                     overwrite=True)
+                assert self.github.config.user_pass is None
 
     @mock.patch('gitsome.github.click.secho')
     @mock.patch('gitsome.config.Config.authenticate_cached_credentials')
@@ -181,6 +201,7 @@ class ConfigTest(unittest.TestCase):
     @mock.patch('gitsome.github.click.secho')
     @mock.patch('gitsome.config.Config.authenticate_cached_credentials')
     def test_authenticate_enterprise_pass(self, mock_auth, mock_click_secho):
+        self.github.config.getpass.return_value = 'bar'
         with mock.patch('click.confirm', return_value=True):
             with mock.patch('builtins.input', return_value='foo'):
                 self.github.config.user_login = 'foo'
@@ -188,6 +209,7 @@ class ConfigTest(unittest.TestCase):
                     enterprise=True,
                     enterprise_auth=self.verify_login_pass_url_enterprise,
                     overwrite=True)
+                assert self.github.config.user_pass is not None
 
     @mock.patch('gitsome.github.click.secho')
     def test_check_auth_error(self, mock_click_secho):


### PR DESCRIPTION
Generally not a good idea to store passwords in cleartext, even moreso when a token is generated immediately after authenticating that makes storing the password unnecessary.

Please let me know if there's anything I missed or didn't think of when removing this.
