### PR TITLE
Fix viewing HTML contents in the terminal for GitHub Enterprise users

### DIFF
--- a/gitsome/github.py
+++ b/gitsome/github.py
@@ -900,9 +900,9 @@ class GitHub(object):
         self.config.urls = self.config.load_urls(view_in_browser)
         url = self.config.urls[index-1]
         click.secho('Viewing ' + url + '...', fg=self.config.clr_message)
+        if self.gh_url not in url:
+            url = self.gh_url + url
         if view_in_browser:
-            if self.gh_url not in url:
-                url = self.gh_url + url
             webbrowser.open(url)
         else:
             if 'issues/' in url:
@@ -911,4 +911,4 @@ class GitHub(object):
             elif len(url.split('/')) == 2:
                 self.repository(url)
             else:
-                self.web_viewer.view_url(self.gh_url + url)
+                self.web_viewer.view_url(url)

--- a/gitsome/github.py
+++ b/gitsome/github.py
@@ -69,6 +69,10 @@ class GitHub(object):
         self.web_viewer = WebViewer(self.config)
         self.trend_parser = feedparser
 
+    @property
+    def gh_url(self):
+        return self.config.enterprise_url or self.GH_BASE_URL
+
     def authenticate(func):
         """Decorator that authenticates credentials.
 
@@ -412,7 +416,7 @@ class GitHub(object):
             click.secho('Expected argument: user/repo/#.',
                         fg=self.config.clr_error)
             return
-        url = (self.GH_BASE_URL + user + '/' + repo + '/' +
+        url = (self.gh_url + user + '/' + repo + '/' +
                'issues/' + number)
         self.web_viewer.view_url(url)
 
@@ -655,7 +659,7 @@ class GitHub(object):
             click.secho('Expected argument: user/repo.',
                         fg=self.config.clr_error)
             return
-        self.web_viewer.view_url(self.GH_BASE_URL + user_repo)
+        self.web_viewer.view_url(self.gh_url + user_repo)
 
     @authenticate
     def search_issues(self, query, limit=1000, pager=False):
@@ -815,7 +819,7 @@ class GitHub(object):
             if available.
         """
         if browser:
-            webbrowser.open(self.GH_BASE_URL + user_id)
+            webbrowser.open(self.gh_url + user_id)
         else:
             user = self.config.api.user(user_id)
             if type(user) is null.NullObject:
@@ -897,8 +901,8 @@ class GitHub(object):
         url = self.config.urls[index-1]
         click.secho('Viewing ' + url + '...', fg=self.config.clr_message)
         if view_in_browser:
-            if self.GH_BASE_URL not in url:
-                url = self.GH_BASE_URL + url
+            if self.gh_url not in url:
+                url = self.gh_url + url
             webbrowser.open(url)
         else:
             if 'issues/' in url:
@@ -907,4 +911,4 @@ class GitHub(object):
             elif len(url.split('/')) == 2:
                 self.repository(url)
             else:
-                self.web_viewer.view_url(self.GH_BASE_URL + url)
+                self.web_viewer.view_url(self.gh_url + url)

--- a/gitsome/web_viewer.py
+++ b/gitsome/web_viewer.py
@@ -111,7 +111,8 @@ class WebViewer(object):
         """
         try:
             headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36'}  # NOQA
-            raw_response = requests.get(url, headers=headers)
+            raw_response = requests.get(url, headers=headers,
+                                        verify=self.config.verify_ssl)
         except (requests.exceptions.SSLError,
                 requests.exceptions.ConnectionError) as e:
             contents = 'Error: ' + str(e) + '\n'

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -320,3 +320,9 @@ class GitHubTest(unittest.TestCase):
         self.github.config.load_urls = lambda x: ['user1']
         self.github.view(0)
         mock_view_url.assert_called_with('https://github.com/user1')
+
+    def test_gh_url(self):
+        self.github.config.enterprise_url = 'https://github.intra.example.com'
+        assert self.github.gh_url == 'https://github.intra.example.com'
+        self.github.config.enterprise_url = None
+        assert self.github.gh_url == self.github.GH_BASE_URL


### PR DESCRIPTION
make gitHub enterprise users can use it correctly