### PR TITLE
Update error hint from gh gitignores to gh gitignore-templates

### DIFF
--- a/gitsome/github.py
+++ b/gitsome/github.py
@@ -391,7 +391,7 @@ class GitHub(object):
         else:
             click.secho(('Invalid case-sensitive template requested, run the '
                          'following command to see available templates:\n'
-                         '    gh gitignores'),
+                         '    gh gitignore-templates'),
                         fg=self.config.clr_error)
 
     @authenticate

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -164,7 +164,7 @@ class GitHubTest(unittest.TestCase):
         mock_click_secho.assert_called_with(
             ('Invalid case-sensitive template requested, run the '
              'following command to see available templates:\n'
-             '    gh gitignores'),
+             '    gh gitignore-templates'),
             fg=self.github.config.clr_error)
 
     @mock.patch('gitsome.github.click.secho')


### PR DESCRIPTION
Now 'gh gitignores' is not supported.