### PR TITLE
Configurable default prompt

### DIFF
--- a/.gitsomeconfig
+++ b/.gitsomeconfig
@@ -21,4 +21,6 @@ clr_tooltip = None
 clr_user = cyan
 clr_view_link = magenta
 clr_view_index = magenta
+prompt = {BOLD_RED}{user} {BOLD_WHITE}at {BOLD_RED}{hostname} {BOLD_WHITE}in {BOLD_GREEN}{cwd} {BOLD_WHITE}on{branch_color}{curr_branch} {BOLD_WHITE}
+	${NO_COLOR}
 

--- a/gitsome/config.py
+++ b/gitsome/config.py
@@ -123,6 +123,7 @@ class Config(object):
     CONFIG_CLR_VIEW_LINK = 'clr_view_link'
     CONFIG_CLR_VIEW_INDEX = 'clr_view_index'
     CONFIG_SECTION = 'github'
+    CONFIG_PROMPT = 'prompt'
     CONFIG_USER_LOGIN = 'user_login'
     CONFIG_USER_PASS = 'user_pass'
     CONFIG_USER_TOKEN = 'user_token'
@@ -144,8 +145,10 @@ class Config(object):
         self.verify_ssl = True
         self.urls = []
         self._init_colors()
+        self._init_prompt()
         self.load_configs([
             self.load_config_colors,
+            self.load_prompt,
         ])
         self.login = login
         self.authorize = authorize
@@ -173,6 +176,18 @@ class Config(object):
         self.clr_user = 'cyan'
         self.clr_view_link = 'magenta'
         self.clr_view_index = 'magenta'
+
+    def _init_prompt(self):
+        """Initialize prompt to its default."""
+        self.prompt = ('{BOLD_RED}{user} '
+                       '{BOLD_WHITE}at '
+                       '{BOLD_RED}{hostname} '
+                       '{BOLD_WHITE}in '
+                       '{BOLD_GREEN}{cwd} '
+                       '{BOLD_WHITE}on'
+                       '{branch_color}{curr_branch} '
+                       '{BOLD_WHITE}\n'
+                       '${NO_COLOR} ')
 
     def authenticate_cached_credentials(self, config, parser,
                                         enterprise_auth=enterprise_login):
@@ -549,6 +564,17 @@ class Config(object):
             default=self.clr_view_index,
             color_config=True)
 
+    def load_prompt(self, parser):
+        """Load prompt from ~/.gitsomeconfig.
+
+        :type parser: :class:`ConfigParser.RawConfigParser`
+        :param parser: An instance of `ConfigParser.RawConfigParser`.
+        """
+        self.prompt = self.load_config(
+            parser=parser,
+            cfg_label=self.CONFIG_PROMPT,
+            default=self.prompt)
+
     def load_urls(self, view_in_browser):
         """Load the current set of urls from ~/.gitsomeconfigurl.
 
@@ -703,6 +729,9 @@ class Config(object):
             parser.set(self.CONFIG_SECTION,
                        self.CONFIG_CLR_VIEW_INDEX,
                        self.clr_view_index)
+            parser.set(self.CONFIG_SECTION,
+                       self.CONFIG_PROMPT,
+                       self.prompt)
             with open(config, 'w+') as config_file:
                 parser.write(config_file)
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -11,7 +11,7 @@ from warnings import warn
 from functools import wraps
 from collections import MutableMapping, MutableSequence, MutableSet, namedtuple
 
-import gitsome.config
+from gitsome.config import Config
 from xonsh import __version__ as XONSH_VERSION
 from xonsh.tools import TERM_COLORS, ON_WINDOWS, ON_MAC, ON_LINUX, ON_ARCH, \
     is_int, always_true, always_false, ensure_string, is_env_path, str_to_env_path, \
@@ -80,24 +80,8 @@ def is_callable_default(x):
     """Checks if a value is a callable default."""
     return callable(x) and getattr(x, '_xonsh_callable_default', False)
 
-#DEFAULT_PROMPT = ('{BOLD_RED}{user} '
-#                  '{BOLD_WHITE}at '
-#                  '{BOLD_RED}{hostname} '
-#                  '{BOLD_WHITE}in '
-#                  '{BOLD_GREEN}{cwd} '
-#                  '{BOLD_WHITE}on'
-#                  '{branch_color}{curr_branch} '
-#                  '{BOLD_WHITE}\n'
-#                  '${NO_COLOR} ')
-DEFAULT_PROMPT = ('{BOLD_RED}{user} '
-                  '{BOLD_BLACK}at '
-                  '{BOLD_RED}{hostname} '
-                  '{BOLD_BLACK}in '
-                  '{BOLD_GREEN}{cwd} '
-                  '{BOLD_BLACK}on'
-                  '{branch_color}{curr_branch} '
-                  '{BOLD_BLACK}\n'
-                  '${NO_COLOR} ')
+config = Config()
+DEFAULT_PROMPT = config.prompt
 DEFAULT_TITLE = '{user} at {hostname}: {cwd} | xonsh'
 
 @default_value

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -11,6 +11,7 @@ from warnings import warn
 from functools import wraps
 from collections import MutableMapping, MutableSequence, MutableSet, namedtuple
 
+import gitsome.config
 from xonsh import __version__ as XONSH_VERSION
 from xonsh.tools import TERM_COLORS, ON_WINDOWS, ON_MAC, ON_LINUX, ON_ARCH, \
     is_int, always_true, always_false, ensure_string, is_env_path, str_to_env_path, \
@@ -79,14 +80,23 @@ def is_callable_default(x):
     """Checks if a value is a callable default."""
     return callable(x) and getattr(x, '_xonsh_callable_default', False)
 
+#DEFAULT_PROMPT = ('{BOLD_RED}{user} '
+#                  '{BOLD_WHITE}at '
+#                  '{BOLD_RED}{hostname} '
+#                  '{BOLD_WHITE}in '
+#                  '{BOLD_GREEN}{cwd} '
+#                  '{BOLD_WHITE}on'
+#                  '{branch_color}{curr_branch} '
+#                  '{BOLD_WHITE}\n'
+#                  '${NO_COLOR} ')
 DEFAULT_PROMPT = ('{BOLD_RED}{user} '
-                  '{BOLD_WHITE}at '
+                  '{BOLD_BLACK}at '
                   '{BOLD_RED}{hostname} '
-                  '{BOLD_WHITE}in '
+                  '{BOLD_BLACK}in '
                   '{BOLD_GREEN}{cwd} '
-                  '{BOLD_WHITE}on'
+                  '{BOLD_BLACK}on'
                   '{branch_color}{curr_branch} '
-                  '{BOLD_WHITE}\n'
+                  '{BOLD_BLACK}\n'
                   '${NO_COLOR} ')
 DEFAULT_TITLE = '{user} at {hostname}: {cwd} | xonsh'
 


### PR DESCRIPTION
Implementation for https://github.com/donnemartin/gitsome/issues/65

A very simple solution following the style as already loading the colors and saving prompt configuration also to .gitsomeconfig
There isn't further documentation or error checking for what all the prompt options are, but it should easy now to adapt the default colors to a light color scheme what was my motiviation (replacing WHITE with BLACK here does it for me now).