### PR TITLE
Fix #147: Gracefully ignore missing avatar image

### DIFF
--- a/gitsome/lib/img2txt/img2txt.py
+++ b/gitsome/lib/img2txt/img2txt.py
@@ -328,7 +328,7 @@ def img2txt(imgname, maxLen=35, clr='', ansi=False,
         from PIL import Image
         img = load_and_resize_image(imgname, antialias, maxLen)
     except IOError:
-        exit("File not found: " + imgname)
+        return "File not found: " + imgname
     except ImportError:
         return 'PIL not found.'
     # get pixels


### PR DESCRIPTION
Replacing exit() with return results in displaying the error message in place
of the missing avatar image *without* stopping execution of 'gitsome'.