### PR TITLE
Resolves #149: Add option to disable avatar

### DIFF
--- a/.gitsomeconfig
+++ b/.gitsomeconfig
@@ -1,5 +1,6 @@
 [github]
 user_login = None
+enable_avatar = True
 verify_ssl = True
 clr_primary = None
 clr_secondary = green

--- a/gitsome/config.py
+++ b/gitsome/config.py
@@ -652,7 +652,6 @@ class Config(object):
             parser.set(self.CONFIG_SECTION,
                        self.CONFIG_VERIFY_SSL,
                        self.verify_ssl)
-            # Update existing config files without enable_avatar correctly
             if self.enable_avatar is not None:
                 parser.set(self.CONFIG_SECTION,
                            self.CONFIG_ENABLE_AVATAR,

--- a/gitsome/config.py
+++ b/gitsome/config.py
@@ -99,6 +99,9 @@ class Config(object):
 
     :type verify_ssl: bool
     :param verify_ssl: Determines whether to verify SSL certs.
+
+    :type enable_avatar: bool
+    :param enable_avatar: Determines whether to request avatar image.
     """
 
     CONFIG = '.gitsomeconfig'
@@ -133,6 +136,7 @@ class Config(object):
     CONFIG_URL_SECTION = 'url'
     CONFIG_URL_LIST = 'url_list'
     CONFIG_AVATAR = '.gitsomeconfigavatar.png'
+    CONFIG_ENABLE_AVATAR = 'enable_avatar'
 
     def __init__(self):
         self.api = None
@@ -143,6 +147,7 @@ class Config(object):
         self.enterprise_url = None
         self.verify_ssl = True
         self.urls = []
+        self.enable_avatar = True
         self._init_colors()
         self.load_configs([
             self.load_config_colors,
@@ -204,6 +209,10 @@ class Config(object):
             self.verify_ssl = self.load_config(
                 parser=parser,
                 cfg_label=self.CONFIG_VERIFY_SSL,
+                boolean_config=True)
+            self.enable_avatar = self.load_config(
+                parser=parser,
+                cfg_label=self.CONFIG_ENABLE_AVATAR,
                 boolean_config=True)
             self.user_feed = self.load_config(
                 parser=parser,
@@ -643,6 +652,11 @@ class Config(object):
             parser.set(self.CONFIG_SECTION,
                        self.CONFIG_VERIFY_SSL,
                        self.verify_ssl)
+            # Update existing config files without enable_avatar correctly
+            if self.enable_avatar is not None:
+                parser.set(self.CONFIG_SECTION,
+                           self.CONFIG_ENABLE_AVATAR,
+                           self.enable_avatar)
             parser.set(self.CONFIG_SECTION,
                        self.CONFIG_CLR_PRIMARY,
                        self.clr_primary)

--- a/gitsome/config.py
+++ b/gitsome/config.py
@@ -638,6 +638,10 @@ class Config(object):
                 parser.set(self.CONFIG_SECTION,
                            self.CONFIG_USER_FEED,
                            self.user_feed)
+            if self.enable_avatar is not None:
+                parser.set(self.CONFIG_SECTION,
+                           self.CONFIG_ENABLE_AVATAR,
+                           self.enable_avatar)
             if self.enterprise_url is not None:
                 parser.set(self.CONFIG_SECTION,
                            self.CONFIG_ENTERPRISE_URL,
@@ -652,10 +656,6 @@ class Config(object):
             parser.set(self.CONFIG_SECTION,
                        self.CONFIG_VERIFY_SSL,
                        self.verify_ssl)
-            if self.enable_avatar is not None:
-                parser.set(self.CONFIG_SECTION,
-                           self.CONFIG_ENABLE_AVATAR,
-                           self.enable_avatar)
             parser.set(self.CONFIG_SECTION,
                        self.CONFIG_CLR_PRIMARY,
                        self.clr_primary)

--- a/gitsome/github.py
+++ b/gitsome/github.py
@@ -133,17 +133,19 @@ class GitHub(object):
         """
         if platform.system() == 'Windows':
             text_avatar = True
-        avatar = self.config.get_github_config_path(
-            self.config.CONFIG_AVATAR)
-        try:
-            urllib.request.urlretrieve(url, avatar)
-        except urllib.error.URLError:
-            pass
+        avatar_enabled = self.config.enable_avatar
         avatar_text = ''
-        if os.path.exists(avatar):
-            avatar_text = self.img2txt(avatar, ansi=(not text_avatar))
-            avatar_text += '\n'
-            os.remove(avatar)
+        if avatar_enabled:
+            avatar = self.config.get_github_config_path(
+                self.config.CONFIG_AVATAR)
+            try:
+                urllib.request.urlretrieve(url, avatar)
+            except urllib.error.URLError:
+                pass
+            if os.path.exists(avatar):
+                avatar_text = self.img2txt(avatar, ansi=(not text_avatar))
+                avatar_text += '\n'
+                os.remove(avatar)
         return avatar_text
 
     def avatar_setup(self, url, text_avatar):


### PR DESCRIPTION
Configuring `disable_avatar = True` will stop `gitsome` from requesting avatar images (#149). If `disable_avatar` option is missing, it's added correctly, thus not breaking existing config files.
```
$ grep avatar .gitsomeconfig
disable_avatar = True
```
