### PR TITLE
Fix Python 3.8 SyntaxWarning: "is not" with a literal

### DIFF
--- a/gitsome/github.py
+++ b/gitsome/github.py
@@ -791,7 +791,7 @@ class GitHub(object):
             webbrowser.open(
                 ('https://github.com/trending' +
                  ('/developers' if devs else '') +
-                 ('/' + language if language is not 'overall' else '') +
+                 ('/' + language if language != 'overall' else '') +
                  url_param))
         else:
             click.secho(


### PR DESCRIPTION
```
/usr/lib/python3/dist-packages/gitsome/github.py:792: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  ('/' + language if language is not 'overall' else '') +
```

This is a new warning added in Python 3.8. From the release notes:

> The compiler now produces a SyntaxWarning when identity checks (is and is not) are used with certain types of literals (e.g. strings, numbers). These can often work by accident in CPython, but are not guaranteed by the language spec. The warning advises users to use equality tests (== and !=) instead. (Contributed by Serhiy Storchaka in bpo-34850.)