### PR TITLE
Fix Python 3.8 SyntaxWarning: "is not" with a literal

### DIFF
--- a/gitsome/lib/html2text/html2text.py
+++ b/gitsome/lib/html2text/html2text.py
@@ -92,8 +92,8 @@ for k in unifiable.keys():
 def onlywhite(line):
     """Return true if the line does only consist of whitespace characters."""
     for c in line:
-        if c is not ' ' and c is not '  ':
-            return c is ' '
+        if c != ' ' and c != '  ':
+            return c == ' '
     return line
 
 def hn(tag):


### PR DESCRIPTION
```
/usr/lib/python3/dist-packages/gitsome/lib/html2text/html2text.py:95: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if c is not ' ' and c is not '  ':
/usr/lib/python3/dist-packages/gitsome/lib/html2text/html2text.py:95: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if c is not ' ' and c is not '  ':
/usr/lib/python3/dist-packages/gitsome/lib/html2text/html2text.py:96: SyntaxWarning: "is" with a literal. Did you mean "=="?
  return c is ' '
```

This is a new warning added in Python 3.8. From the release notes:

> The compiler now produces a SyntaxWarning when identity checks (is and is not) are used with certain types of literals (e.g. strings, numbers). These can often work by accident in CPython, but are not guaranteed by the language spec. The warning advises users to use equality tests (== and !=) instead. (Contributed by Serhiy Storchaka in bpo-34850.)