### PR TITLE
docs: fix simple typo, recurssion -> recursion

### DIFF
--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -1004,7 +1004,7 @@ class FileThreadDispatcher:
         that this method can be used in a with-statement.
         """
         if handle is self:
-            # prevent weird recurssion errors
+            # prevent weird recursion errors
             return self
         self.registry[threading.get_ident()] = handle
         return self


### PR DESCRIPTION
There is a small typo in xonsh/proc.py.

Should read `recursion` rather than `recurssion`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md