### PR TITLE
Fix: allow feedparser 6.0.2 to solve issues in Python 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ def main():
             'colorama>=0.3.3,<1.0.0',
             'click>=5.1,<7.0',
             'pygments>=2.0.2,<3.0.0',
-            'feedparser>=5.2.1,<6.0.0',
+            'feedparser>=5.2.1,<=6.0.2',
             'pytz>=2016.3,<2017.0',
             'docopt>=0.6.2,<1.0.0',
             'uritemplate.py>=1.0.0,<4.0.0',


### PR DESCRIPTION
Python 3.9 changes the way `base64.decodestring` works, which results in `AttributeErrors` in gitsome. Expanding the version range for feedparser to include `6.0.2` solves these issues. Addresses #186 