### PR TITLE
Add support for python 3.10

### DIFF
--- a/gitsome/lib/github3/session.py
+++ b/gitsome/lib/github3/session.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import requests
 
-from collections import Callable
+from collections.abc import Callable
 from . import __version__
 from logging import getLogger
 from contextlib import contextmanager

--- a/gitsome/lib/github3/structs.py
+++ b/gitsome/lib/github3/structs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import collections
+import collections.abc
 import functools
 
 from requests.compat import urlparse, urlencode
@@ -8,7 +8,7 @@ from . import exceptions
 from . import models
 
 
-class GitHubIterator(models.GitHubCore, collections.Iterator):
+class GitHubIterator(models.GitHubCore, collections.abc.Iterator):
     """The :class:`GitHubIterator` class powers all of the iter_* methods."""
     def __init__(self, count, url, cls, session, params=None, etag=None,
                  headers=None):

--- a/gitsome/lib/github3/utils.py
+++ b/gitsome/lib/github3/utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """A collection of useful utilities."""
-import collections
+import collections.abc
 import datetime
 import re
 
@@ -81,7 +81,7 @@ def stream_response_to_file(response, path=None):
     fd = None
     filename = None
     if path:
-        if isinstance(getattr(path, 'write', None), collections.Callable):
+        if isinstance(getattr(path, 'write', None), collections.abc.Callable):
             pre_opened = True
             fd = path
             filename = getattr(fd, 'name', None)


### PR DESCRIPTION
Use 'collections.abc' instead of 'collections' since python 3.10 does not accept
this syntax anymore, it has been deprecated since python 3.3.

Signed-off-by: Alexandre Ghiti <alexandre.ghiti@canonical.com>