### PR TITLE
Eliminate warning on Python 3.8 or later

### DIFF
--- a/gitsome/github.py
+++ b/gitsome/github.py
@@ -791,7 +791,7 @@ class GitHub(object):
             webbrowser.open(
                 ('https://github.com/trending' +
                  ('/developers' if devs else '') +
-                 ('/' + language if language is not 'overall' else '') +
+                 ('/' + language if language != 'overall' else '') +
                  url_param))
         else:
             click.secho(

--- a/gitsome/lib/html2text/html2text.py
+++ b/gitsome/lib/html2text/html2text.py
@@ -92,8 +92,8 @@ for k in unifiable.keys():
 def onlywhite(line):
     """Return true if the line does only consist of whitespace characters."""
     for c in line:
-        if c is not ' ' and c is not '  ':
-            return c is ' '
+        if c != ' ' and c != '  ':
+            return c == ' '
     return line
 
 def hn(tag):


### PR DESCRIPTION
If `is not` or `is` is used to compare literals, Python will complain on 3.8 or later. Change this to use `!=` and `==` instead.